### PR TITLE
fix typo in appveyor build and test script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,9 +22,9 @@ platform: Any CPU
 # Execute psake build task
 build_script:
   - ps: >-
-      Inboke-Build -Task 'Build'
+      Invoke-Build -Task 'Build'
 
 # Execute psake test and analyze task
 test_script:
   - ps: >-
-      Inboke-Build -Task 'Test'
+      Invoke-Build -Task 'Test'


### PR DESCRIPTION
I think the command in the appveyor build file should be Invoke-Build instead of Inboke-Build. 